### PR TITLE
Optimise mem

### DIFF
--- a/src/XSim.jl
+++ b/src/XSim.jl
@@ -11,6 +11,13 @@ tempPos=Array{Float64}(undef,100000)
 tempOri=Array{Int64}(undef,100000)
 tempMut=Array{Float64}(undef,100000)
 
+"""
+base type for genotype and Haplotype storage.
+Shouldn't be exported but needs to be defined. Used throughout the included src files.
+Originally an Int64
+"""
+const AlleleIndexType = Int8
+
 include("genome/genome.jl")
 include("cohort/cohort.jl")
 include("output/output.jl")

--- a/src/cohort/cohort.jl
+++ b/src/cohort/cohort.jl
@@ -1,7 +1,9 @@
 #Types and Methods for Simulating Genotypes of Animals
 
+const AlleleIndexType = Int8
+
 mutable struct Chromosome
-    haplotype::Array{Int64,1}
+    haplotype::Array{AlleleIndexType,1}
     ori::Array{Int64,1}
     pos::Array{Float64,1}
     mut::Array{Float64,1}
@@ -32,8 +34,8 @@ function Animal(mySire::Int64, myDam::Int64)
     my.myID   = common.countId
     common.countId += 1
     for i in 1:common.G.numChrom
-        my.genomePat[i]=Chromosome(Array{Int64}(undef,0),Array{Int64}(undef,0),Array{Float64}(undef,0),Array{Float64}(undef,0))
-        my.genomeMat[i]=Chromosome(Array{Int64}(undef,0),Array{Int64}(undef,0),Array{Float64}(undef,0),Array{Float64}(undef,0))
+        my.genomePat[i]=Chromosome(Array{AlleleIndexType}(undef,0),Array{Int64}(undef,0),Array{Float64}(undef,0),Array{Float64}(undef,0))
+        my.genomeMat[i]=Chromosome(Array{AlleleIndexType}(undef,0),Array{Int64}(undef,0),Array{Float64}(undef,0),Array{Float64}(undef,0))
     end
     return my
 end

--- a/src/cohort/cohort.jl
+++ b/src/cohort/cohort.jl
@@ -1,6 +1,5 @@
 #Types and Methods for Simulating Genotypes of Animals
 
-const AlleleIndexType = Int8
 
 mutable struct Chromosome
     haplotype::Array{AlleleIndexType,1}

--- a/src/cohort/founders.jl
+++ b/src/cohort/founders.jl
@@ -36,8 +36,8 @@ function initFounderHaps(my::Animal,hapFile)
     if hapFile != false
       #hap1  =float(split(readline(hapFile))[2:end])
       #hap2  =float(split(readline(hapFile))[2:end])
-      hap1  = parse.(Float64, split(readline(hapFile))[2:end])
-      hap2  = parse.(Float64, split(readline(hapFile))[2:end])
+      hap1  = parse.(AlleleIndexType, split(readline(hapFile))[2:end])
+      hap2  = parse.(AlleleIndexType, split(readline(hapFile))[2:end])
       k=1
       for i in 1:numberChromosomePair
         numLoci=common.G.chr[i].numLoci
@@ -57,9 +57,9 @@ function initFounderHaps(my::Animal,hapFile)
         Base.resize!(my.genomeMat[i].haplotype,numLoci)
 
         for j in 1:numLoci
-            p=common.G.chr[i].loci[j].allele_freq[1]
-            my.genomePat[i].haplotype[j]=rand(Bernoulli(p))
-            my.genomeMat[i].haplotype[j]=rand(Bernoulli(p))
+            p=Bernoulli(common.G.chr[i].loci[j].allele_freq[1])
+            my.genomePat[i].haplotype[j]=convert(AlleleIndexType,rand(p))
+            my.genomeMat[i].haplotype[j]=convert(AlleleIndexType,rand(p))
         end
     end
 end

--- a/src/output/genotype.jl
+++ b/src/output/genotype.jl
@@ -12,7 +12,7 @@ function getOurGenotypes(my::Cohort)
         nLoci=nLoci+common.G.chr[i].numLoci
     end
 
-    npMatrix=Array{Int64}(undef,length(my.animalCohort), nLoci)
+    npMatrix=Array{AlleleIndexType}(undef,length(my.animalCohort), nLoci)
     for (i,value) in enumerate(my.animalCohort)
         npMatrix[i,:]=getMyGenotype(value)
     end
@@ -28,7 +28,7 @@ function getOurHaps(my::Cohort)
 end
 
 function getMyGenotype(my)
-    myGenotype=Array{Int64}(undef,0)
+    myGenotype=Array{AlleleIndexType}(undef,0)
     for i in 1:common.G.numChrom
         append!(myGenotype, my.genomePat[i].haplotype+my.genomeMat[i].haplotype)
     end


### PR DESCRIPTION
# Description 
This is a quick request to reduce memory storage by using 8 bit Int8's instead of Int64 for genotypes and the haplotype storage. 
On a small dataset it reduced memory useage by half - aiming for 100K animals per annum with 10K markers.
Currently with Int64 100K*10K = 1G of genotypes per annum. ie 8 GB for Int64 . This should reduce it to 1 GB.

# Testing
This has been compiled and run once to succesful completion on a laptop. The changes implicitly assume haplotypes are  0 or 1 and genotypes are 0,1 or 2. No overflow checking or enforcement is carried out. 
  