### PR TITLE
Profiling

### DIFF
--- a/src/XSim.jl
+++ b/src/XSim.jl
@@ -7,10 +7,6 @@ using JWAS
 using Printf
 using LinearAlgebra
 
-tempPos=Array{Float64}(undef,100000)
-tempOri=Array{Int64}(undef,100000)
-tempMut=Array{Float64}(undef,100000)
-
 """
 base type for genotype and Haplotype storage.
 Shouldn't be exported but needs to be defined. Used throughout the included src files.

--- a/src/cohort/cohort.jl
+++ b/src/cohort/cohort.jl
@@ -22,7 +22,7 @@ end
 
 mutable struct Cohort
     animalCohort::Array{Animal,1}
-    npMatrix::Array{Int64,2}
+    npMatrix::Array{AlleleIndexType,2}
 end
 
 function Animal(mySire::Int64, myDam::Int64)

--- a/src/cohort/nonfounders.jl
+++ b/src/cohort/nonfounders.jl
@@ -201,9 +201,9 @@ function sampleOnePosOri(genome::Array{Chromosome,1},parent::Animal)
         binomialN=convert(Int64,ceil(chrLength*3+1))
         numCrossover=rand(Binomial(binomialN,chrLength/binomialN))
         rec=[0.0]
-
+        sizehint!(rec,100)
         for irec in 1:numCrossover
-            push!(rec,chrLength*rand(1)[1])
+            push!(rec,chrLength*rand())
         end
 
         push!(rec,chrLength)
@@ -211,8 +211,13 @@ function sampleOnePosOri(genome::Array{Chromosome,1},parent::Animal)
 
         numTemp=1
         numTempMut=0
+        
+        tempPos=Array{Float64}(undef,1000)
+        tempOri=Array{Int64}(undef,1000)
+        tempMut=Array{Float64}(undef,1000)
+        
         for j in 1:(length(rec)-1)
-            for k in 1:length(currentChrom.pos)
+            for k in eachindex(currentChrom.pos)
               if currentChrom.pos[k] >= rec[j] && currentChrom.pos[k] < rec[j+1]
                 tempPos[numTemp]=currentChrom.pos[k]
                 tempOri[numTemp]=currentChrom.ori[k]
@@ -221,7 +226,7 @@ function sampleOnePosOri(genome::Array{Chromosome,1},parent::Animal)
                 break
               end
             end
-            for k in 1:length(currentChrom.mut)
+            for k in eachindex(currentChrom.mut)
               if currentChrom.mut[k] >= rec[j] && currentChrom.mut[k] < rec[j+1]
                   numTempMut = numTempMut+1
                   tempMut[numTempMut] = currentChrom.mut[k]

--- a/src/genome/genome.jl
+++ b/src/genome/genome.jl
@@ -45,7 +45,7 @@ function get_num_alleles(my::LocusInfo)
     return length(my.allele_freq)
 end
 
-function get_num_chrom(my)
+function get_num_chrom(my::GenomeInfo)
     return my.numChrom
 end
 

--- a/src/output/genotype.jl
+++ b/src/output/genotype.jl
@@ -71,11 +71,7 @@ function getOneHaps(genome::Array{Chromosome,1})
             prevSegLen += segLen
             segLen   = 0
             if segment < numOri
-               numLociUntilGuessedPos = round(Int64, endPos * lociPerM)
-               numLociUntilGuessedPos = maximum([1,numLociUntilGuessedPos])
-               if numLociUntilGuessedPos > numLoci
-                   numLociUntilGuessedPos = numLoci
-               end
+               numLociUntilGuessedPos = clamp(round(Int64, endPos * lociPerM),1::Int64, numLoci)
                guessedPos = chrom.mapPos[numLociUntilGuessedPos]
                if guessedPos > endPos
                   ul = numLociUntilGuessedPos

--- a/src/output/genotype.jl
+++ b/src/output/genotype.jl
@@ -27,7 +27,7 @@ function getOurHaps(my::Cohort)
     end
 end
 
-function getMyGenotype(my)
+function getMyGenotype(my::Animal)
     myGenotype=Array{AlleleIndexType}(undef,0)
     for i in 1:common.G.numChrom
         append!(myGenotype, my.genomePat[i].haplotype+my.genomeMat[i].haplotype)
@@ -35,7 +35,7 @@ function getMyGenotype(my)
     return myGenotype
 end
 
-function getMyHaps(my)
+function getMyHaps(my::Animal)
     getOneHaps(my.genomePat)
     getOneHaps(my.genomeMat)
 end
@@ -64,7 +64,7 @@ function getOneHaps(genome::Array{Chromosome,1})
             #println("getOneHaps(): segment=",segment)
             flush(stdout)
             whichFounder=ceil(Integer,genome[i].ori[segment]/2)
-            genomePatorMatInThisFounder=(genome[i].ori[segment]%2==0) ? common.founders[whichFounder].genomeMat[i] : common.founders[whichFounder].genomePat[i]
+            genomePatorMatInThisFounder::Chromosome=(genome[i].ori[segment]%2==0) ? common.founders[whichFounder].genomeMat[i] : common.founders[whichFounder].genomePat[i]
 
             startPos = genome[i].pos[segment]
             endPos   = genome[i].pos[segment+1]
@@ -135,7 +135,7 @@ function getOneHaps(genome::Array{Chromosome,1})
 
         for j in 1:length(genome[i].mut)
             whichlocus = findfirst(common.G.chr[i].mapPos .== genome[i].mut[j])
-            genome[i].haplotype[whichlocus] = 1 - genome[i].haplotype[whichlocus]
+            genome[i].haplotype[whichlocus] = 1::AlleleIndexType - genome[i].haplotype[whichlocus]
         end
 
         pop!(genome[i].pos) #remove temporary added chrLength


### PR DESCRIPTION
# Description 
A collection of commits following some intitial Julia profiling.
On my desktop example they reduce user runtime from 3m41 to 3m11 ie. a 13% reduction in user run time.
The desktop example pedigree contains 240,000 animals. 
The commits contain the following general changes.
1. Global temporary storage in XSim.jl was moved into the stack of nonfounders.jl. This is proposed to make a later multithreading using @threads easier. The memory requested was reduced.
2. A number  of type declarations were sprinkled around (possibly excessively). These locations were identified by profiling tools. 
3. use of a clamp function.
4. rewrite the recombination vector to exactly allocate the memory needed in advance and in one hit.
# Testing
The random number was seeded to a fixed value.
The 240,000 animals desktop example was run with the master branch and the proposed branch.
Output (.gen, .ped, .phe) files md5sum's were computed and found to be identical.   